### PR TITLE
Close file handles of Popen

### DIFF
--- a/src/markdown_katex/wrapper.py
+++ b/src/markdown_katex/wrapper.py
@@ -205,7 +205,7 @@ def _write_tex2html(cmd_parts: typ.List[str], tex: str, tmp_output_file: pl.Path
     cmd_parts.extend(["--input", str(tmp_input_file), "--output", str(tmp_output_file)])
     proc = None
     try:
-        proc = sp.Popen(cmd_parts, stdout=sp.PIPE, stderr=sp.PIPE)
+        proc     = sp.Popen(cmd_parts, stdout=sp.PIPE, stderr=sp.PIPE)
         ret_code = proc.wait()
         if ret_code < 0:
             signame = SIG_NAME_BY_NUM[abs(ret_code)]
@@ -293,9 +293,9 @@ def _get_cmd_help_text() -> str:
     # pylint: disable=consider-using-with ; not supported on py27
     bin_parts = get_bin_cmd()
     cmd_parts = bin_parts + ['--help']
-    proc = None
+    proc      = None
     try:
-        proc = sp.Popen(cmd_parts, stdout=sp.PIPE)
+        proc      = sp.Popen(cmd_parts, stdout=sp.PIPE)
         help_text = read_output(proc.stdout)
     finally:
         if proc is not None and proc.stdout is not None:

--- a/src/markdown_katex/wrapper.py
+++ b/src/markdown_katex/wrapper.py
@@ -290,6 +290,7 @@ DEFAULT_HELP_TEXT = DEFAULT_HELP_TEXT.replace("\n", " ").replace("NL", "\n")
 
 
 def _get_cmd_help_text() -> str:
+    # pylint: disable=consider-using-with ; not supported on py27
     bin_parts = get_bin_cmd()
     cmd_parts = bin_parts + ['--help']
     proc = None

--- a/src/markdown_katex/wrapper.py
+++ b/src/markdown_katex/wrapper.py
@@ -194,6 +194,7 @@ class KatexError(Exception):
 
 
 def _write_tex2html(cmd_parts: typ.List[str], tex: str, tmp_output_file: pl.Path) -> None:
+    # pylint: disable=consider-using-with ; not supported on py27
     tmp_input_file = TMP_DIR / tmp_output_file.name.replace(".html", ".tex")
     input_data     = tex.encode(KATEX_INPUT_ENCODING)
 

--- a/src/markdown_katex/wrapper.py
+++ b/src/markdown_katex/wrapper.py
@@ -202,22 +202,22 @@ def _write_tex2html(cmd_parts: typ.List[str], tex: str, tmp_output_file: pl.Path
         fobj.write(input_data)
 
     cmd_parts.extend(["--input", str(tmp_input_file), "--output", str(tmp_output_file)])
-    proc     = sp.Popen(cmd_parts, stdout=sp.PIPE, stderr=sp.PIPE)
-    ret_code = proc.wait()
-    if ret_code < 0:
-        signame = SIG_NAME_BY_NUM[abs(ret_code)]
-        err_msg = (
-            f"Error processing '{tex}': "
-            + "katex_cli process ended with "
-            + f"code {ret_code} ({signame})"
-        )
-        raise KatexError(err_msg)
-    elif ret_code > 0:
-        stdout  = read_output(proc.stdout)
-        errout  = read_output(proc.stderr)
-        output  = (stdout + "\n" + errout).strip()
-        err_msg = f"Error processing '{tex}': {output}"
-        raise KatexError(err_msg)
+    with sp.Popen(cmd_parts, stdout=sp.PIPE, stderr=sp.PIPE) as proc:
+        ret_code = proc.wait()
+        if ret_code < 0:
+            signame = SIG_NAME_BY_NUM[abs(ret_code)]
+            err_msg = (
+                f"Error processing '{tex}': "
+                + "katex_cli process ended with "
+                + f"code {ret_code} ({signame})"
+            )
+            raise KatexError(err_msg)
+        elif ret_code > 0:
+            stdout  = read_output(proc.stdout)
+            errout  = read_output(proc.stderr)
+            output  = (stdout + "\n" + errout).strip()
+            err_msg = f"Error processing '{tex}': {output}"
+            raise KatexError(err_msg)
 
     tmp_input_file.unlink()
 
@@ -281,8 +281,8 @@ DEFAULT_HELP_TEXT = DEFAULT_HELP_TEXT.replace("\n", " ").replace("NL", "\n")
 def _get_cmd_help_text() -> str:
     bin_parts = get_bin_cmd()
     cmd_parts = bin_parts + ['--help']
-    proc      = sp.Popen(cmd_parts, stdout=sp.PIPE)
-    help_text = read_output(proc.stdout)
+    with sp.Popen(cmd_parts, stdout=sp.PIPE) as proc:
+        help_text = read_output(proc.stdout)
     return help_text
 
 


### PR DESCRIPTION
First of all, thanks for this awesome project. We recently added it to our WeasyPrint pipeline and enjoying it so far!

However, python started complaining that certain files/processes have been left unclosed:

```
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py:1052: ResourceWarning: subprocess 4157 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback

/path/to/project/venv/lib/python3.9/site-packages/markdown_katex/wrapper.py:285: ResourceWarning: unclosed file <_io.BufferedReader name=6>
  help_text = _get_cmd_help_text()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

To fix this, I closed all file descriptors simply by wrapping the calls to Popen with a context manager as specified in the python documentation.

See: https://docs.python.org/3/library/subprocess.html#popen-constructor