### PR TITLE
Fix No such file or directory: `/tmp/mdkatex/...`

### DIFF
--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -7,7 +7,7 @@
 # Binary (non-pure) packages may also be listed here, but you
 # should see if there is a conda package that suits your needs.
 
-Markdown>=3.0<3.3;python_version<"3.6"
+Markdown>=3.0,<3.3;python_version<"3.6"
 Markdown>=3.0;python_version>="3.6"
 typing;python_version<"3.5"
 pathlib2

--- a/src/markdown_katex/wrapper.py
+++ b/src/markdown_katex/wrapper.py
@@ -29,7 +29,7 @@ SIG_NAME_BY_NUM = {
 assert SIG_NAME_BY_NUM[15] == 'SIGTERM'
 
 
-TMP_DIR = pl.Path(tempfile.gettempdir()) / "mdkatex"
+TMP_DIR = pl.Path(tempfile.mkdtemp("mdkatex"))
 
 LIBDIR: pl.Path = pl.Path(__file__).parent
 PKG_BIN_DIR      = LIBDIR / "bin"


### PR DESCRIPTION
This fixes issue #16 (So far, I've not run into this error anymore with this fix.)

I also had to correct the requirements file to make `pip install -e .` work.
See https://pip.pypa.io/en/stable/reference/requirement-specifiers/#examples