### PR TITLE
changing the hash function

### DIFF
--- a/src/markdown_katex/extension.py
+++ b/src/markdown_katex/extension.py
@@ -42,7 +42,7 @@ def _clean_block_text(block_text: str) -> str:
 
 def make_marker_id(text: str) -> str:
     data = text.encode("utf-8")
-    return hashlib.md5(data).hexdigest()
+    return hashlib.sha256(data).hexdigest()
 
 
 def svg2img(html: str) -> str:


### PR DESCRIPTION
Hello,

Federal Information Processing Standards (FIPS) compliant machines can not compute a md5 hash, which prevents certain U.S. government employees (like me) from using your nice plugin. This is briefly mentioned in the [hashlib docs](FIPS compliant).
```
    return hashlib.md5(data).hexdigest()
ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
```


The fix is to just use another hash. I used sha256 since it is so widely used else where

